### PR TITLE
Added Redis cache

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,71 @@
 {
   "name": "tailorfetch",
-  "version": "1.1.1",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tailorfetch",
-      "version": "1.1.1",
-      "license": "ISC",
+      "version": "1.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "redis": "^4.6.7"
+      },
       "devDependencies": {
         "@types/node": "^20.4.9"
+      }
+    },
+    "node_modules/@redis/bloom": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-1.2.0.tgz",
+      "integrity": "sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/client": {
+      "version": "1.5.8",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.5.8.tgz",
+      "integrity": "sha512-xzElwHIO6rBAqzPeVnCzgvrnBEcFL1P0w8P65VNLRkdVW8rOE58f52hdj0BDgmsdOm4f1EoXPZtH4Fh7M/qUpw==",
+      "dependencies": {
+        "cluster-key-slot": "1.1.2",
+        "generic-pool": "3.9.0",
+        "yallist": "4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@redis/graph": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@redis/graph/-/graph-1.1.0.tgz",
+      "integrity": "sha512-16yZWngxyXPd+MJxeSr0dqh2AIOi8j9yXKcKCwVaKDbH3HTuETpDVPcLujhFYVPtYrngSco31BUcSa9TH31Gqg==",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/json": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-1.0.4.tgz",
+      "integrity": "sha512-LUZE2Gdrhg0Rx7AN+cZkb1e6HjoSKaeeW8rYnt89Tly13GBI5eP4CwDVr+MY8BAYfCg4/N15OUrtLoona9uSgw==",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/search": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-1.1.3.tgz",
+      "integrity": "sha512-4Dg1JjvCevdiCBTZqjhKkGoC5/BcB7k9j99kdMnaXFXg8x4eyOIVg9487CMv7/BUVkFLZCaIh8ead9mU15DNng==",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/time-series": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-1.0.4.tgz",
+      "integrity": "sha512-ThUIgo2U/g7cCuZavucQTQzA9g9JbDDY2f64u3AbAoz/8vE2lt2U37LamDUVChhaDA3IRT9R6VvJwqnUfTJzng==",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
       }
     },
     "node_modules/@types/node": {
@@ -17,6 +73,40 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.9.tgz",
       "integrity": "sha512-8e2HYcg7ohnTUbHk8focoklEQYvemQmu9M/f43DZVx43kHn0tE3BY/6gSDxS7k0SprtS0NHvj+L80cGLnoOUcQ==",
       "dev": true
+    },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/generic-pool": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.9.0.tgz",
+      "integrity": "sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/redis": {
+      "version": "4.6.7",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-4.6.7.tgz",
+      "integrity": "sha512-KrkuNJNpCwRm5vFJh0tteMxW8SaUzkm5fBH7eL5hd/D0fAkzvapxbfGPP/r+4JAXdQuX7nebsBkBqA2RHB7Usw==",
+      "dependencies": {
+        "@redis/bloom": "1.2.0",
+        "@redis/client": "1.5.8",
+        "@redis/graph": "1.1.0",
+        "@redis/json": "1.0.4",
+        "@redis/search": "1.1.3",
+        "@redis/time-series": "1.0.4"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,5 +19,8 @@
   "license": "MIT",
   "devDependencies": {
     "@types/node": "^20.4.9"
+  },
+  "dependencies": {
+    "redis": "^4.6.7"
   }
 }

--- a/src/IRequestOptions.ts
+++ b/src/IRequestOptions.ts
@@ -1,5 +1,8 @@
 import BaseTransform from "./BaseTransform";
 import {BufferSource} from "stream/web";
+import {createClient} from 'redis';
+
+type redisClient = ReturnType<typeof createClient>;
 
 export default interface IRequestOptions {
     headers?: {[key: string]: string};
@@ -13,6 +16,7 @@ export default interface IRequestOptions {
     requestCredentials?: "omit" | "same-origin" | "include",
     cache?: {
         expiresIn: number;
+        redisClient?: redisClient
     },
     retry?: {
         maxRetries: number;

--- a/src/Request.ts
+++ b/src/Request.ts
@@ -169,8 +169,7 @@ export default class Request {
         const cacheKey = Cache.generateCacheKey(this.method, this.urlStr.toString(), this.requestOptions);
 
         if (this.method === 'GET') {
-            const cacheResponse = Cache.get(cacheKey);
-            console.log(cacheKey);
+            const cacheResponse = await Cache.get(cacheKey, this.requestOptions);
             if (cacheResponse) {
                 return new TailorResponse(cacheResponse, this.response?.status, this.response?.statusText, this.requestOptions.headers, this.requestOptions, true);
             }
@@ -180,7 +179,7 @@ export default class Request {
             if (this.requestOptions.parseJSON) {
                 const transformedResponse = this.requestOptions.transformResponse.transform(JSON.parse(await response.text()), this.requestOptions);
                 if (this.requestOptions.cache) {
-                    Cache.set(cacheKey, transformedResponse, this.requestOptions.cache.expiresIn);
+                    Cache.set(cacheKey, transformedResponse, this.requestOptions, this.requestOptions.cache.expiresIn);
                 }
                 return new TailorResponse(transformedResponse, this.response?.status, this.response?.statusText, this.requestOptions.headers, this.requestOptions);
             }
@@ -188,7 +187,7 @@ export default class Request {
             const transformedResponse = this.requestOptions.transformResponse.transform(await response.text(), this.requestOptions);
 
             if (this.requestOptions.cache) {
-                Cache.set(cacheKey, transformedResponse, this.requestOptions.cache.expiresIn);
+                Cache.set(cacheKey, transformedResponse, this.requestOptions, this.requestOptions.cache.expiresIn);
             }
 
             return new TailorResponse(transformedResponse, this.response?.status, this.response?.statusText, this.requestOptions.headers, this.requestOptions);
@@ -198,14 +197,14 @@ export default class Request {
             const jsonResponse = JSON.parse(await response.text());
 
             if (this.requestOptions.cache) {
-                Cache.set(cacheKey, jsonResponse, this.requestOptions.cache.expiresIn);
+                Cache.set(cacheKey, jsonResponse, this.requestOptions, this.requestOptions.cache.expiresIn);
             }
 
             return new TailorResponse(jsonResponse, this.response?.status, this.response?.statusText, this.requestOptions.headers, this.requestOptions);
         }
 
         if (this.requestOptions.cache) {
-            Cache.set(cacheKey, response.text(), this.requestOptions.cache.expiresIn);
+            Cache.set(cacheKey, response.text(), this.requestOptions,  this.requestOptions.cache.expiresIn);
         }
 
         return new TailorResponse(response.text(), this.response?.status, this.response?.statusText, this.requestOptions.headers, this.requestOptions);


### PR DESCRIPTION
Added an option to enable Redis cache by supplying Redis client to request parameters

```ts
const client = createClient();
client.connect();

TailorFetch.GET('https://example.com/api/example/endpint', {
  cache: {
    expiresIn: 60000,
    redisClient: Client
  }
});

```